### PR TITLE
Fix retrieving of users within a schedule layer

### DIFF
--- a/pagerduty/schedules.go
+++ b/pagerduty/schedules.go
@@ -29,18 +29,23 @@ type Schedule struct {
 	FinalSchedule        *ScheduleLayer      `json:"final_schedule,omitempty"`
 }
 
+type OrderedUser struct {
+	Order int  `json:"member_order,omitempty"`
+	User  User `json:"user"`
+}
+
 type ScheduleLayer struct {
-	Name                       string   `json:"name,omitempty"`
-	RenderedScheduleEntries    []string `json:"rendered_schedule_entries,omitempty"`
-	RestrictionType            string   `json:"restriction_type,omitempty"`
-	Restrictions               []string `json:"restrictions,omitempty"`
-	Priority                   int      `json:"priority,omitempty"`
-	Start                      string   `json:"start,omitempty"`
-	End                        string   `json:"end,omitempty"`
-	RenderedCoveragePercentage int      `json:"rendered_coverage_percentage,omitempty"`
-	RotationTurnLengthSeconds  int      `json:"rotation_turn_length_seconds,omitempty"`
-	RotationVirtualStart       string   `json:"rotation_virtual_start,omitempty"`
-	Users                      []*User  `json:"users,omitempty"`
+	Name                       string         `json:"name,omitempty"`
+	RenderedScheduleEntries    []string       `json:"rendered_schedule_entries,omitempty"`
+	RestrictionType            string         `json:"restriction_type,omitempty"`
+	Restrictions               []string       `json:"restrictions,omitempty"`
+	Priority                   int            `json:"priority,omitempty"`
+	Start                      string         `json:"start,omitempty"`
+	End                        string         `json:"end,omitempty"`
+	RenderedCoveragePercentage int            `json:"rendered_coverage_percentage,omitempty"`
+	RotationTurnLengthSeconds  int            `json:"rotation_turn_length_seconds,omitempty"`
+	RotationVirtualStart       string         `json:"rotation_virtual_start,omitempty"`
+	Users                      []*OrderedUser `json:"users,omitempty"`
 }
 
 type Schedules struct {

--- a/pagerduty/schedules_test.go
+++ b/pagerduty/schedules_test.go
@@ -63,7 +63,7 @@ func TestSchedulesService_Get(t *testing.T) {
 
 	mux.HandleFunc("/schedules/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"schedule": {"id": "ABCDEF"}}`)
+		fmt.Fprint(w, `{"schedule": {"id": "ABCDEF", "schedule_layers":[{"name":"Schedule Layer 1", "users":[{"member_order":1,"user":{"id":"GHIJK","name":"User Name"}}]}]}}`)
 	})
 
 	schedule, _, err := client.Schedules.Get("s")
@@ -71,7 +71,9 @@ func TestSchedulesService_Get(t *testing.T) {
 		t.Errorf("Schedules.Get returned error: %v", err)
 	}
 
-	want := &Schedule{ID: "ABCDEF"}
+	want := &Schedule{ID: "ABCDEF", ScheduleLayers: []*ScheduleLayer{
+		{Name: "Schedule Layer 1", Users: []*OrderedUser{{Order: 1, User: User{ID: "GHIJK", Name: "User Name"}}}},
+	}}
 	if !reflect.DeepEqual(schedule, want) {
 		t.Errorf("Schedules.Get returned %+v, want %%+v", schedule, want)
 	}


### PR DESCRIPTION
The API returns an object with "member_order" and "user" fields, e.g.

{"member_order":1,"user":{"id":"UID","name":"User Name","email":"a@b.com","color":"olivedrab"}}